### PR TITLE
Fix compilation on iOS 15

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,10 @@ BMCManager.shared.thankYouMessage = "Thank you for supporting 🎉 App Craft Stu
 4. Add a `BMCButton` to your storyboard, XIB file, or instantiate it programmatically. To add the button to your storyboard or XIB file, add a View and set its custom class to `BMCButton`.
 5. **Optional**: If you want to customize the button, do the following:
 ```swift
-let button = BMCButton(configuration: .default)
-button.configuraton = .init(color: .orange, font: .cookie)
+let configuration = BMCButton.Configuration(color: .orange, font: .cookie)
+let button = BMCButton(configuration: configuration)
+// or set the burtton configuration later
+button.configure(with: configuration)
 ```
 
 <p align="center">

--- a/Sources/BuyMeACoffee/BMCButton.swift
+++ b/Sources/BuyMeACoffee/BMCButton.swift
@@ -30,11 +30,7 @@ public class BMCButton: UIButton {
         return numberFormatter
     }()
     
-    public var configuration: Configuration = .default {
-        didSet {
-            configure(with: configuration)
-        }
-    }
+    private var _configuration: Configuration = .default
     
     public override var isHighlighted: Bool {
         didSet {
@@ -45,7 +41,7 @@ public class BMCButton: UIButton {
     public convenience init(configuration: Configuration) {
         self.init(type: .custom)
         
-        self.configuration = configuration
+        self._configuration = configuration
     }
     
     override init(frame: CGRect) {
@@ -66,6 +62,25 @@ public class BMCButton: UIButton {
         super.prepareForInterfaceBuilder()
         
         setup()
+    }
+    
+    // MARK: - Public functions
+    
+    public func configure(with configuration: Configuration) {
+        titleLabel?.font = configuration.font.value
+        setTitleColor(configuration.color.title, for: .normal)
+        setImage(configuration.color.cup, for: .normal)
+        backgroundColor = configuration.color.background
+        
+        var title = configuration.title
+        if let product = BMCManager.shared.product {
+            numberFormatter.locale = product.priceLocale
+            if let price = numberFormatter.string(from: product.price) {
+                title.append(" (\(price))")
+            }
+        }
+
+        setTitle(title, for: .normal)
     }
     
     // MARK: - Private functions
@@ -89,24 +104,7 @@ public class BMCButton: UIButton {
         
         addTarget(BMCManager.shared, action: #selector(BMCManager.shared.start), for: .touchUpInside)
         
-        configure(with: configuration)
-    }
-    
-    private func configure(with configuration: Configuration) {
-        titleLabel?.font = configuration.font.value
-        setTitleColor(configuration.color.title, for: .normal)
-        setImage(configuration.color.cup, for: .normal)
-        backgroundColor = configuration.color.background
-        
-        var title = configuration.title
-        if let product = BMCManager.shared.product {
-            numberFormatter.locale = product.priceLocale
-            if let price = numberFormatter.string(from: product.price) {
-                title.append(" (\(price))")
-            }
-        }
-
-        setTitle(title, for: .normal)
+        configure(with: _configuration)
     }
     
     private func registerFonts() {

--- a/Tests/buymeacoffeeTests/BuyMeACoffeeTests.swift
+++ b/Tests/buymeacoffeeTests/BuyMeACoffeeTests.swift
@@ -18,7 +18,7 @@ final class BuyMeACoffeeTests: XCTestCase {
         }
         
         let button = BMCButton(frame: .init(x: 0, y: 0, width: 200, height: 50))
-        button.configuration = .default
+        button.configure(with: .default)
                 
         if let data = button.snapshot().pngData() {
             let url = url.appendingPathComponent("snapshot-bmc-button").appendingPathExtension("png")


### PR DESCRIPTION
The BMCButton `configuration` property now overrides the new iOS 15 UIButton `configuration` variable.
I've decided to make it private and prefix the variable name with an underscore character.

To configure BMCButton object, you can now use the `configure(with:)` function or `init(configuration:)` initializer.
Fix for #9 issue.